### PR TITLE
Code review

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,7 @@
+Making shallow copies results in the following memory allocation error:
+
+(Sample)
+
+friendBook(4171,0x1000b15c0) malloc: *** error for object 0x10105f2a0: pointer being freed was not allocated
+
+We resolve this by refactoring our code to perform deep copies.


### PR DESCRIPTION
Making shallow copies results in the following memory allocation error:

(Sample)

`friendBook(4171,0x1000b15c0) malloc: *** error for object 0x10105f2a0: pointer being freed was not allocated`

We resolve this by refactoring our code to perform deep copies.